### PR TITLE
MouseBot and Direction Order Change

### DIFF
--- a/Controller.cpp
+++ b/Controller.cpp
@@ -6,34 +6,9 @@ using namespace std;
 namespace Micromouse
 {
 
-	ostream& operator<<(ostream &out, const Vector::Pos &pos)
-	{
-		int x = pos.x();
-		return out << "(" << pos.x() << ", " << pos.y() << ")";
-	}
-
 	Controller::Controller()
 	{
-		MouseBot mb = MouseBot();
-		cout << mb.getPos() << endl;
 
-		mb.moveForward();
-		cout << mb.getPos() << endl;
-
-		mb.turnRight();
-		cout << mb.getPos() << endl;
-
-		mb.moveForward();
-		cout << mb.getPos() << endl;
-
-		mb.rotateLeft();
-		mb.rotateLeft();
-		cout << mb.getPos() << endl;
-
-		mb.moveForward();
-		cout << mb.getPos() << endl;
-
-		system("pause");
 	}
 
 

--- a/Controller.cpp
+++ b/Controller.cpp
@@ -1,14 +1,39 @@
 #include <iostream>
 #include "Controller.h"
 
+using namespace std;
 
 namespace Micromouse
 {
 
-
+	ostream& operator<<(ostream &out, const Vector::Pos &pos)
+	{
+		int x = pos.x();
+		return out << "(" << pos.x() << ", " << pos.y() << ")";
+	}
 
 	Controller::Controller()
 	{
+		MouseBot mb = MouseBot();
+		cout << mb.getPos() << endl;
+
+		mb.moveForward();
+		cout << mb.getPos() << endl;
+
+		mb.turnRight();
+		cout << mb.getPos() << endl;
+
+		mb.moveForward();
+		cout << mb.getPos() << endl;
+
+		mb.rotateLeft();
+		mb.rotateLeft();
+		cout << mb.getPos() << endl;
+
+		mb.moveForward();
+		cout << mb.getPos() << endl;
+
+		system("pause");
 	}
 
 

--- a/Controller.h
+++ b/Controller.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Maze.h"
+#include "MouseBot.h"
 
 
 namespace Micromouse

--- a/Maze.cpp
+++ b/Maze.cpp
@@ -58,7 +58,10 @@ namespace Micromouse
 			openNodes.pop_back();
 			currentNode->close();
 
-			for ( direction dir = direction::E; dir != direction::NONE; ++dir )
+			// Uses old direction order
+			//for (direction dir = E; dir != direction::NONE; ++dir)
+
+			for (direction dir = N; dir != NONE; ++dir)
 				//loop through neighbor nodes
 			{
 				neighborNode = getNeighborNode( currentNode->getPos() , dir );
@@ -144,11 +147,11 @@ namespace Micromouse
 		/*       x
 			 -1  0  1
 			----------
-		 -1| NW| N |NE|
+		  1| NW| N |NE|
 		   |---+---+--|
 		y 0| W |   | E|
 		   |---+---+--|
-		  1| SW| s  SE|
+		 -1| SW| s  SE|
 			----------
 		*/
 

--- a/Maze.cpp
+++ b/Maze.cpp
@@ -132,13 +132,15 @@ namespace Micromouse
 	// returns a pointer to the neighbor node at direction dir from pos
 	Node * Maze::getNeighborNode( Vector::Pos pos , direction dir )
 	{
-		int x = pos.x() + dir % 3 - 1;
-		int y = pos.y() + dir / 3 - 1;
+		// Uses old direction enum order
+		// int x = pos.x() + dir % 3 - 1;
+		// int y = pos.y() + dir / 3 - 1;
+		//if (x >= 0 && x < NUM_NODES_W && y >= 0 && y < NUM_NODES_H) { return maze[x][y]; }
 
-		if ( x >= 0 && x < NUM_NODES_W && y >= 0 && y < NUM_NODES_H )
-		{
-			return maze[ x ][ y ];
-		}
+		Vector::Pos offsetPos = pos + dir;
+		
+		return maze[offsetPos.x()][offsetPos.y()];
+
 		/*       x
 			 -1  0  1
 			----------

--- a/MicroMouse-2016.vcxproj
+++ b/MicroMouse-2016.vcxproj
@@ -152,12 +152,14 @@
     <ClCompile Include="Controller.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Maze.cpp" />
+    <ClCompile Include="MouseBot.cpp" />
     <ClCompile Include="Path.cpp" />
     <ClCompile Include="Vector.cpp" />
     <ClCompile Include="Node.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Controller.h" />
+    <ClInclude Include="MouseBot.h" />
     <ClInclude Include="Maze.h" />
     <ClInclude Include="Path.h" />
     <ClInclude Include="Vector.h" />

--- a/MicroMouse-2016.vcxproj.filters
+++ b/MicroMouse-2016.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="Path.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MouseBot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Maze.h">
@@ -48,6 +51,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Path.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MouseBot.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MouseBot.cpp
+++ b/MouseBot.cpp
@@ -48,13 +48,35 @@ namespace Micromouse
 
 	void MouseBot::move(direction dir)
 	{
-
+		pos = pos + dir;
 	}
 
 	void MouseBot::moveForward()
 	{
-
+		move(facing);
 	}
 
+	void MouseBot::turnLeft()
+	{
+		facing = facing % NW;
+		moveForward();
+		facing = facing % NW;
+	}
 
+	void MouseBot::turnRight()
+	{
+		facing = facing % NE;
+		moveForward();
+		facing = facing % NE;
+	}
+
+	void MouseBot::rotateLeft()
+	{
+		facing = facing % W;
+	}
+
+	void MouseBot::rotateRight()
+	{
+		facing = facing % E;
+	}
 }

--- a/MouseBot.cpp
+++ b/MouseBot.cpp
@@ -34,6 +34,11 @@ namespace Micromouse
 		return pos;
 	}
 
+	direction MouseBot::getFacing()
+	{
+		return facing;
+	}
+
 	void MouseBot::setPos(int x, int y)
 	{
 		setPos(Vector::Pos(x, y));

--- a/MouseBot.cpp
+++ b/MouseBot.cpp
@@ -1,0 +1,60 @@
+/*********************************\
+File:			MouseBot.cpp
+Creation date:	3/2/2016
+Author Name:	Joshua Murphy
+Author GitHub:	joshuasrjc
+\*********************************/
+
+#include <iostream>
+#include "MouseBot.h"
+
+namespace Micromouse
+{
+	/**** CONSTRUCTORS ****/
+
+	MouseBot::MouseBot()
+	{
+		setPos(Vector::Pos(0, 0));
+	}
+
+	MouseBot::MouseBot(int x, int y)
+	{
+		setPos(Vector::Pos(x, y));
+	}
+
+	MouseBot::MouseBot(Vector::Pos pos)
+	{
+		setPos(pos);
+	}
+
+	/**** SET / GET FUNCTIONS ****/
+
+	Vector::Pos MouseBot::getPos()
+	{
+		return pos;
+	}
+
+	void MouseBot::setPos(int x, int y)
+	{
+		setPos(Vector::Pos(x, y));
+	}
+
+	void MouseBot::setPos(Vector::Pos pos)
+	{
+		this->pos = pos;
+	}
+
+	/**** MOVEMENT FUNCTIONS ****/
+
+	void MouseBot::move(direction dir)
+	{
+
+	}
+
+	void MouseBot::moveForward()
+	{
+
+	}
+
+
+}

--- a/MouseBot.cpp
+++ b/MouseBot.cpp
@@ -58,25 +58,25 @@ namespace Micromouse
 
 	void MouseBot::turnLeft()
 	{
-		facing = facing % NW;
+		facing = facing + NW;
 		moveForward();
-		facing = facing % NW;
+		facing = facing + NW;
 	}
 
 	void MouseBot::turnRight()
 	{
-		facing = facing % NE;
+		facing = facing + NE;
 		moveForward();
-		facing = facing % NE;
+		facing = facing + NE;
 	}
 
 	void MouseBot::rotateLeft()
 	{
-		facing = facing % W;
+		facing = facing + W;
 	}
 
 	void MouseBot::rotateRight()
 	{
-		facing = facing % E;
+		facing = facing + E;
 	}
 }

--- a/MouseBot.h
+++ b/MouseBot.h
@@ -1,0 +1,38 @@
+/*********************************\
+File:			MouseBot.h
+Creation date:	3/2/2016
+Author Name:	Joshua Murphy
+Author GitHub:	joshuasrjc
+\*********************************/
+
+#pragma once
+#include "Vector.h"
+
+namespace Micromouse
+{
+	//A class to be used for keeping track of the robot's position, as well as an interface to the I/O of the robot.
+	class MouseBot
+	{
+	public:
+		MouseBot();								// Uses a default position of (0,0)
+		MouseBot(int x, int y);					// Sets the position to (x,y)
+		MouseBot(Vector::Pos pos);
+
+		Vector::Pos getPos();					// Returns the position of the mouse
+		void setPos(int x, int y);				// Sets the position to (x,y)
+		void setPos(Vector::Pos pos);			// Sets the position to pos
+
+		void moveForward();						// Moves the mouse forward by 1 node (1/2 cell)
+		void turnLeft();						// Moves the mouse forward and to the left, turning 90 degrees.
+		void turnRight();						// Moves the mouse forward and to the right, turning 90 degrees.
+		void rotateLeft();						// Rotates the mouse in place to the left by 90 degrees.
+		void rotateRight();						// Rotates the mouse in place to the right by 90 degrees.
+
+	private:
+
+		void move(direction dir);
+
+		Vector::Pos pos = Vector::Pos(0,0);
+		direction facing = N;
+	};
+}

--- a/MouseBot.h
+++ b/MouseBot.h
@@ -19,6 +19,7 @@ namespace Micromouse
 		MouseBot(Vector::Pos pos);
 
 		Vector::Pos getPos();					// Returns the position of the mouse
+		direction getFacing();					// Return the direction the mouse is facing.
 		void setPos(int x, int y);				// Sets the position to (x,y)
 		void setPos(Vector::Pos pos);			// Sets the position to pos
 

--- a/Vector.cpp
+++ b/Vector.cpp
@@ -92,7 +92,7 @@ namespace Micromouse
 			assert( _y < NUM_NODES_H );
 
 			// no Pos should have a position at two odd coordinates
-			//assert( ( _x % 2 != 1 ) && ( _y % 2 != 1 ) );
+			assert( ( _x % 2 != 1 ) && ( _y % 2 != 1 ) );
 		}
 
 

--- a/Vector.cpp
+++ b/Vector.cpp
@@ -63,7 +63,7 @@ namespace Micromouse
 			assert( _x < NUM_NODES_W );
 			assert( _y < NUM_NODES_H );
 
-			// no Node should exist at two odd coordinates
+			// no Pos should have a position at two odd coordinates
 			assert( ( _x % 2 != 1 ) && ( _y % 2 != 1 ) );
 		}
 

--- a/Vector.cpp
+++ b/Vector.cpp
@@ -1,19 +1,39 @@
 #include "Vector.h"
 #include <assert.h>
-#include <iostream>
 
 using namespace std;
 
 namespace Micromouse
 {
-	direction operator%(const direction &dir1, const direction &dir2)
+	direction operator+(const direction &dir1, const direction &dir2)
 	{
-		return static_cast<direction>((dir1 + dir2) % 8);
+		return static_cast<direction>(((int)dir1 + (int)dir2) % 8);
+	}
+
+	direction operator-(const direction &dir1, const direction &dir2)
+	{
+		return static_cast<direction>(((int)dir1 - (int)dir2) % 8);
 	}
 
 	direction& operator++(direction& dir)
 	{ //++prefix
-		return dir = dir % NE;
+		return dir = static_cast<direction>(((int)dir + 1) % 9);
+	}
+
+	ostream& operator<<(ostream& out, const direction& dir)
+	{
+		switch (dir)
+		{
+		case N:  return out << "N";
+		case NE: return out << "NE";
+		case E:  return out << "E";
+		case SE: return out << "SE";
+		case S:  return out << "S";
+		case SW: return out << "SW";
+		case W:  return out << "W";
+		case NW: return out << "NW";
+		default: return out << "NONE";
+		}
 	}
 
 	//static const Pos & UNDEFINED = Pos( 0 , -1 );
@@ -92,7 +112,7 @@ namespace Micromouse
 			assert( _y < NUM_NODES_H );
 
 			// no Pos should have a position at two odd coordinates
-			assert( ( _x % 2 != 1 ) && ( _y % 2 != 1 ) );
+			assert( ( _x % 2 == 0 ) || ( _y % 2 == 0 ) );
 		}
 
 

--- a/Vector.cpp
+++ b/Vector.cpp
@@ -56,6 +56,21 @@ namespace Micromouse
 
 
 
+		Pos Pos::operator+(direction dir)
+		{
+			int x = _x;
+			int y = _y;
+
+			if (dir == NE || dir == E || dir == SE) { x++; }
+			if (dir == NW || dir == W || dir == SW) { x--; }
+			if (dir == SE || dir == S || dir == SW) { y++; }
+			if (dir == NE || dir == N || dir == NW) { y--; }
+
+			return Pos(x, y);
+		}
+
+
+
 		void Pos::validateSelf()
 		{
 			assert( _x >= 0 );
@@ -122,18 +137,5 @@ namespace Micromouse
 
 			assert( _mag < NUM_NODES_W || _mag < NUM_NODES_H );
 		}
-	}
-
-
-	direction& operator++( direction& dir )
-	{ //++prefix
-		if ( dir == direction::SE )
-		{
-			return dir = direction::NW; // rollover
-		}
-
-		int temp = dir;
-
-		return dir = static_cast<direction> ( ++temp );
 	}
 }

--- a/Vector.cpp
+++ b/Vector.cpp
@@ -1,8 +1,21 @@
 #include "Vector.h"
 #include <assert.h>
+#include <iostream>
+
+using namespace std;
 
 namespace Micromouse
 {
+	direction operator%(const direction &dir1, const direction &dir2)
+	{
+		return static_cast<direction>((dir1 + dir2) % 8);
+	}
+
+	direction& operator++(direction& dir)
+	{ //++prefix
+		return dir = dir % NE;
+	}
+
 	//static const Pos & UNDEFINED = Pos( 0 , -1 );
 
 	namespace Vector
@@ -24,14 +37,14 @@ namespace Micromouse
 
 
 
-		int Pos::x()
+		int Pos::x() const
 		{
 			return _x;
 		}
 
 
 
-		int Pos::y()
+		int Pos::y() const
 		{
 			return _y;
 		}
@@ -61,10 +74,10 @@ namespace Micromouse
 			int x = _x;
 			int y = _y;
 
+			if (dir == NE || dir == N || dir == NW) { y++; }
 			if (dir == NE || dir == E || dir == SE) { x++; }
+			if (dir == SE || dir == S || dir == SW) { y--; }
 			if (dir == NW || dir == W || dir == SW) { x--; }
-			if (dir == SE || dir == S || dir == SW) { y++; }
-			if (dir == NE || dir == N || dir == NW) { y--; }
 
 			return Pos(x, y);
 		}
@@ -79,7 +92,7 @@ namespace Micromouse
 			assert( _y < NUM_NODES_H );
 
 			// no Pos should have a position at two odd coordinates
-			assert( ( _x % 2 != 1 ) && ( _y % 2 != 1 ) );
+			//assert( ( _x % 2 != 1 ) && ( _y % 2 != 1 ) );
 		}
 
 

--- a/Vector.h
+++ b/Vector.h
@@ -19,9 +19,22 @@ namespace Micromouse
 	SW  s  SE
 	*/
 	// TODO: move into own namespace maybe?
-	enum direction { NW , N , NE , W , NONE , E , SW , S , SE };
-	
-	direction& operator++( direction& dir );
+
+	//Old enum order
+	//enum direction { NW , N , NE , W , NONE , E , SW , S , SE };
+
+	enum direction { N, NE, E, SE, S, SW, W, NW, NONE };
+
+	direction operator+(const direction &dir1, const direction &dir2)
+	{
+		return static_cast<direction>( (dir1 + dir2) % 8 );
+	}
+
+
+	direction& operator++( direction& dir )
+	{ //++prefix
+		return dir = dir + NE;
+	}
 
 	namespace Vector
 	{
@@ -36,9 +49,10 @@ namespace Micromouse
 
 			int x(); // return x
 			int y(); // return y 
-			void x( int x ); // set x, 0<=x<NUM_NODES_W
-			void y( int y ); // set y, 0<=y<NUM_NODES_H
+			void x( int x ); // set x, 0 <= x < NUM_NODES_W
+			void y( int y ); // set y, 0 <= y < NUM_NODES_H
 
+			Pos operator+(direction dir); // Returns a Pos that has been offset in the given direction.
 
 			// static const Vector::Pos& UNDEFINED;//a Vector that represents an undefined Vector
 

--- a/Vector.h
+++ b/Vector.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <iostream>
+
+using namespace std;
+
 namespace Micromouse
 {
 	//number of cells in maze
@@ -25,11 +29,20 @@ namespace Micromouse
 
 	enum direction { N, NE, E, SE, S, SW, W, NW, NONE };
 
-	// --Rotate Function: dir1 % dir2 --
+	// Rotate Operator: dir1 + dir2
 	// Returns dir1, rotated in the direction of dir2,
 	// where north is forward, east is right, south is backward, etc.
-	direction operator%(const direction &dir1, const direction &dir2);
+	direction operator+(const direction &dir1, const direction &dir2);
+	direction operator-(const direction &dir1, const direction &dir2);
+
+	// Increment operator (prefix)
+	// dir is incremented by 1 (45 degrees to the right),
+	// and then returned. NE will be incremented to NONE,
+	// signifying the last direction. NONE will be incremented
+	// to N.
 	direction& operator++(direction& dir);
+
+	ostream& operator<<(ostream& out, const direction& dir);
 
 	namespace Vector
 	{

--- a/Vector.h
+++ b/Vector.h
@@ -25,16 +25,11 @@ namespace Micromouse
 
 	enum direction { N, NE, E, SE, S, SW, W, NW, NONE };
 
-	direction operator+(const direction &dir1, const direction &dir2)
-	{
-		return static_cast<direction>( (dir1 + dir2) % 8 );
-	}
-
-
-	direction& operator++( direction& dir )
-	{ //++prefix
-		return dir = dir + NE;
-	}
+	// --Rotate Function: dir1 % dir2 --
+	// Returns dir1, rotated in the direction of dir2,
+	// where north is forward, east is right, south is backward, etc.
+	direction operator%(const direction &dir1, const direction &dir2);
+	direction& operator++(direction& dir);
 
 	namespace Vector
 	{
@@ -47,8 +42,8 @@ namespace Micromouse
 			Pos( int x , int y );
 			~Pos();
 
-			int x(); // return x
-			int y(); // return y 
+			int x() const; // return x
+			int y() const; // return y 
 			void x( int x ); // set x, 0 <= x < NUM_NODES_W
 			void y( int y ); // set y, 0 <= y < NUM_NODES_H
 


### PR DESCRIPTION
# Changed
### enum direction

The order of the direction enum was changed from:  
{ NW , N , NE , W , NONE , E , SW , S , SE }  
to  
{ N, NE, E, SE, S, SW, W, NW, NONE }  
In addition, north is now the positive Y direction
### getNeighborNode

The getNeightborNode function in Maze depended on the old direction order, and was changed to use the offset overload function described below.
# Added
### MouseBot Class

Added a mouse class that keeps track of position and direction. It also has functions to move around.
### Direction overloads

Two overload functions using the direction enum were added.  
Rotate: dir1 % dir2 now returns dir1, rotated in the direction of dir2, with north being straight ahead.  
Offset: pos + dir now returns a position, offset in the direction of dir by 1 unit in each direction.
# Tested
## MouseBot

The movement functions of MouseBot have been tested, and works as expected.
## The maze class has not been tested.
