### PR TITLE
Benji calibration memory

### DIFF
--- a/MicroMouse-2016.vcxproj
+++ b/MicroMouse-2016.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="micromouse\Controller.cpp" />
     <ClCompile Include="micromouse\FlagMatrix.cpp" />
     <ClCompile Include="micromouse\Maze.cpp" />
+    <ClCompile Include="micromouse\Memory.cpp" />
     <ClCompile Include="micromouse\Motor.cpp" />
     <ClCompile Include="micromouse\MouseBot.cpp" />
     <ClCompile Include="micromouse\Node.cpp" />
@@ -168,6 +169,7 @@
     <ClInclude Include="micromouse\FlagMatrix.h" />
     <ClInclude Include="micromouse\Logger.h" />
     <ClInclude Include="micromouse\Maze.h" />
+    <ClInclude Include="micromouse\Memory.h" />
     <ClInclude Include="micromouse\Motor.h" />
     <ClInclude Include="micromouse\MouseBot.h" />
     <ClInclude Include="micromouse\Node.h" />

--- a/MicroMouse-2016.vcxproj.filters
+++ b/MicroMouse-2016.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="micromouse\PIDControl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="micromouse\Memory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="micromouse\Controller.h">
@@ -93,6 +96,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="micromouse\PIDControl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="micromouse\Memory.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/micromouse/IRSensor.h
+++ b/micromouse/IRSensor.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <assert.h>
+#include "Memory.h"
 
 namespace Micromouse
 {

--- a/micromouse/IRSensor.h
+++ b/micromouse/IRSensor.h
@@ -23,6 +23,8 @@ namespace Micromouse
 		~IRSenor();
 
 		bool calibrate( int calibrationStart, int calibrationInterval );
+		bool loadCalibration( int address );
+		void saveCalibration( int address );
 
 		// returns the distance in mm
 		// will return a value between MIN_RANGE and MAX_RANGE

--- a/micromouse/Memory.cpp
+++ b/micromouse/Memory.cpp
@@ -1,0 +1,24 @@
+#include "Memory.h"
+#include <assert.h>
+
+namespace Micromouse {
+
+	int Memory::read(int address)
+	{
+		assert(address >= 0 && address < 2048);
+
+#ifdef __MK20DX256__ // Teensy compile
+		return EEPROM.read(address);
+#endif
+		return 0;
+	}
+
+	void Memory::write(int address, int val)
+	{
+		assert(address >= 0 && address < 2048);
+
+#ifdef __MK20DX256__ // Teensy compile
+		EEPROM.update(address, val);
+#endif
+	}
+}

--- a/micromouse/Memory.h
+++ b/micromouse/Memory.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#ifdef __MK20DX256__
+#include <EEPROM.h>
+#endif
+
+namespace Micromouse {
+
+
+	//0-99 unreserved
+
+
+	/* 
+	100 - 179: IRSensor Calibration Data Block 
+	relative to the starting address
+	0: calibrationSize
+	1: calibrationStart
+	2: calibrationInterval
+	3-19: CalibrationData[]
+	*/
+	const int IR_FRONT_LEFT_MEMORY = 100;//-119
+	const int IR_FRONT_RIGHT_MEMORY = 120;//-139
+	const int IR_LEFT_MEMORY = 140;//-159
+	const int IR_RIGHT_MEMORY = 160;//-179
+
+
+	//180-511 unreserved
+
+	//512-2047 map
+
+
+
+	class Memory
+	{
+	private:
+		Memory() {};//dont instantiate me
+	public:
+		//TODO use byte type??
+		static int read(int address);
+		static void write(int address, int val);
+	};
+}

--- a/micromouse/RobotIO.cpp
+++ b/micromouse/RobotIO.cpp
@@ -244,5 +244,13 @@ namespace Micromouse
 		IRSensors[RIGHT]->calibrate(20, 20);
 		IRSensors[FRONT_LEFT]->calibrate(20, 20);
 		IRSensors[FRONT_RIGHT]->calibrate(20, 20);
+
+		//TODO check if calibrations were good/ ask to save
+		IRSensors[LEFT]->saveCalibration(IR_LEFT_MEMORY);
+		IRSensors[RIGHT]->saveCalibration(IR_RIGHT_MEMORY);
+		IRSensors[FRONT_LEFT]->saveCalibration(IR_FRONT_LEFT_MEMORY);
+		IRSensors[FRONT_RIGHT]->saveCalibration(IR_FRONT_RIGHT_MEMORY);
+
+
 	}
 }

--- a/micromouse/RobotIO.cpp
+++ b/micromouse/RobotIO.cpp
@@ -218,6 +218,14 @@ namespace Micromouse
 		IRSensors[RIGHT] = new IRSenor(IR_RIGHT_PIN, 20, 150);
 		IRSensors[FRONT_LEFT] = new IRSenor(IR_FRONT_LEFT_PIN, 20, 150);
 		IRSensors[FRONT_RIGHT] = new IRSenor(IR_FRONT_RIGHT_PIN, 20, 150);
+
+		//TODO check if load fails
+		IRSensors[LEFT]->loadCalibration(IR_LEFT_MEMORY);
+		IRSensors[RIGHT]->loadCalibration(IR_RIGHT_MEMORY);
+		IRSensors[FRONT_LEFT]->loadCalibration(IR_FRONT_LEFT_MEMORY);
+		IRSensors[FRONT_RIGHT]->loadCalibration(IR_FRONT_RIGHT_MEMORY);
+
+
 	}
 
 	void RobotIO::initPins()

--- a/micromouse/RobotIO.h
+++ b/micromouse/RobotIO.h
@@ -33,6 +33,12 @@ namespace Micromouse
 
 	const int LED_PIN = 13;
 
+	//Memory.h
+	extern const int IR_FRONT_LEFT_MEMORY;
+	extern const int IR_FRONT_RIGHT_MEMORY;
+	extern const int IR_LEFT_MEMORY;
+	extern const int IR_RIGHT_MEMORY;
+
 
 	//A class that contains functions and constants used to communicate with the IO pins of the Teensey 3.2 Microcontroller.
 	// ## NOT YET IMPLEMENTED ##

--- a/micromouse/micromouse.ino
+++ b/micromouse/micromouse.ino
@@ -1,5 +1,5 @@
 #include <Encoder.h>
-
+#include <EEPROM.h>
 //dont ask
 namespace std {
   void __throw_bad_alloc()


### PR DESCRIPTION
- [X] Compiles on desktop
- [X] Complies on Teensy
#### Additions

Add Memory Class

This class acts as the middle man between EEPROM and the rest of the program
currently basic read and write functionality added
memory address have been reserved as follows

0-99 unreserved
100 - 179: IRSensor Calibration
180-511 unreserved
512-2047 map

add save/load calibration to IRSensor

it will attempt to load calibration automatically and falls back on the default if no calibration has been saved

it will save all the calibrations performed
#### Changes

 fixed ir calibration not setting some variables needed to use the calibration
#### Removals
